### PR TITLE
Preprocessing-Resizing layer unit test expansion and refactoring.

### DIFF
--- a/tfjs-layers/src/layers/preprocessing/image_resizing_test.ts
+++ b/tfjs-layers/src/layers/preprocessing/image_resizing_test.ts
@@ -35,34 +35,50 @@ describeMathCPUAndGPU('Resizing Layer', () => {
   });
 
   it('Returns correctly downscaled tensor', () => {
-    // resize and check output content
+    // resize and check output content (not batched)
     const rangeArr = [...Array(16).keys()]; // equivalent to np.arange(0,16)
     const inputArr = [];
-    while(rangeArr.length) inputArr.push(rangeArr.splice(0,4)); // reshape
-    const inputTensor = tensor([inputArr]) as Tensor<Rank.R4>;
+    while(rangeArr.length) {inputArr.push(rangeArr.splice(0,4));} // reshape
+    const inputTensor = tensor(inputArr, [4,4,1]);
     const height = 2;
     const width = 2;
     const interpolation = 'nearest';
     const resizingLayer = new Resizing({height, width, interpolation});
     const layerOutputTensor = resizingLayer.apply(inputTensor) as Tensor;
-    const expectedArr = [[5, 7], [13, 15]];
-    const expectedOutput = tensor([expectedArr]) as Tensor<Rank.R4>;
+    const expectedArr = [[0, 3], [12, 15]];
+    const expectedOutput = tensor(expectedArr, [2,2,1]);
+    expectTensorsClose(layerOutputTensor, expectedOutput);
+  });
+
+  it('Returns correctly downscaled tensor', () => {
+    // resize and check output content (batched)
+    const rangeArr = [...Array(36).keys()]; // equivalent to np.arange(0,16)
+    const inputArr = [];
+    while(rangeArr.length) {inputArr.push(rangeArr.splice(0,6));} // reshape
+    const inputTensor = tensor([inputArr], [1,6,6,1]);
+    const height = 3;
+    const width = 3;
+    const interpolation = 'nearest';
+    const resizingLayer = new Resizing({height, width, interpolation});
+    const layerOutputTensor = resizingLayer.apply(inputTensor) as Tensor;
+    const expectedArr = [[0,3,5], [18,21,23], [30,33,35]];
+    const expectedOutput = tensor([expectedArr], [1,3,3,1]);
     expectTensorsClose(layerOutputTensor, expectedOutput);
   });
 
   it('Returns correctly upscaled tensor', () => {
-    // resize and check output content
+    // resize and check output content (batched)
     const rangeArr = [...Array(4).keys()]; // equivalent to np.arange(0,4)
     const inputArr = [];
-    while(rangeArr.length) inputArr.push(rangeArr.splice(0,2)); // reshape
-    const inputTensor = tensor([inputArr]) as Tensor<Rank.R4>;
+    while(rangeArr.length) {inputArr.push(rangeArr.splice(0,2));} // reshape
+    const inputTensor = tensor([inputArr], [1,2,2,1]);
     const height = 4;
     const width = 4;
     const interpolation = 'nearest';
     const resizingLayer = new Resizing({height, width, interpolation});
     const layerOutputTensor = resizingLayer.apply(inputTensor) as Tensor;
     const expectedArr = [[0,0,1,1], [0,0,1,1], [2,2,3,3], [2,2,3,3]];
-    const expectedOutput = tensor([expectedArr]) as Tensor<Rank.R4>;
+    const expectedOutput = tensor([expectedArr], [1,4,4,1]);
     expectTensorsClose(layerOutputTensor, expectedOutput);
   });
 
@@ -79,8 +95,8 @@ describeMathCPUAndGPU('Resizing Layer', () => {
 
   it('Returns a tensor of the correct dtype', () => {
     // do a same resizing operation, cheeck tensors dtypes and content
-    const height = 40
-    const width = 60
+    const height = 40;
+    const width = 60;
     const numChannels = 3;
     const inputTensor: Tensor<Rank.R3> =
         randomNormal([height, width, numChannels]);


### PR DESCRIPTION
Co-authored-by: Adam Lang <@AdamLang96> (adamglang96@gmail.com)

IMPORTANT NOTES REGARDING TESTING AND OP IMPLEMENTATION OF RESIZING_NEAREST_NEIGHBOR:
The Keras implementation of the image resizing (nearest neighbor) op utilizes a bottom-right corner cell preferential selection for downscaling matrices, whereas the tensorflow.js version seems to implement a top-left default with a right- and bottom- cell bias past the middle of the source array (midpoint selected by floor(length - 1) )

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.